### PR TITLE
fix: MacOS support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bix-invoice",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bix-invoice",
-      "version": "2.0.6",
+      "version": "2.0.8",
       "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.7",
@@ -17,7 +17,7 @@
         "written-number": "^0.11.1"
       },
       "bin": {
-        "bix-invoice": "OPENSSL_CONF=$INIT_CWD/openssl.conf $INIT_CWD/index.js"
+        "bix-invoice": "src/index.js"
       },
       "devDependencies": {
         "express": "^4.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bix-invoice",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Simple invoice generator",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,9 @@ async function init(jsonPath, output = 'pdf') {
 }
 
 async function writeTo(html, output) {
-    const filename = await mktemp(`--suffix=.${output}`);
+    const tmpPrefix = await mktemp('bix-invoice.XXXXXX');
+    const filename = `${tmpPrefix}.${output}`;
+
     switch (output) {
         case 'pdf':
             await write(html, filename);


### PR DESCRIPTION
mktemp does not have --suffix option in mac. 
This PR manually adds the suffix to the generated tmp filename.
It should now work both for latest Mac OS and Linux.